### PR TITLE
OpenID Authentication - Alpha 2

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
 	"parserOptions": {
-		"ecmaVersion": 6,
+		"ecmaVersion": 8,
 		"sourceType": "module",
 		"ecmaFeatures": {
 			"experimentalObjectRestSpread": true
@@ -36,7 +36,8 @@
 
 		"indent": [
 			2,
-			"tab"
+			"tab",
+			{ "MemberExpression": 0 }
 		],
 		"quotes": [
 			1,
@@ -58,7 +59,7 @@
 
 		"no-console": 1,
 		"comma-dangle": [
-			1,
+			2,
 			"always-multiline"
 		],
 		"no-undef": 1,

--- a/src/magister.js
+++ b/src/magister.js
@@ -399,8 +399,8 @@ class Magister {
 					'Ongeldig account of verkeerde combinatie van gebruikersnaam en wachtwoord. Probeer het nog eens of neem contact op met de applicatiebeheerder van de school.',
 					'Je gebruikersnaam en/of wachtwoord is niet correct.',
 				].includes(err.message) ?
-				new AuthError(err.message) :
-				err
+					new AuthError(err.message) :
+					err
 			})
 		}
 

--- a/src/message.js
+++ b/src/message.js
@@ -186,7 +186,8 @@ class Message extends MagisterThing {
 			${this.toString()}
 		`
 		message.subject = `RE: ${this.subject}`
-		message.recipients = _.chain(this.recipients)
+		message.recipients =
+			_.chain(this.recipients)
 			.reject({ id: this._magister.profileInfo.id })
 			.push(this.sender)
 			.value()


### PR DESCRIPTION
- Added OpenID authentication
- Switched from Session ID's to Bearer tokens
- Rewrote some of the HTTP wrapper code to allow options in get requests
- Upgraded node-fetch to allow redirect header extraction
- Upgraded to Node 6 build target to allow async functions