### PR TITLE
Update src/profileInfo.js - fix for getProfilePicture when using parent credentials

### DIFF
--- a/src/profileInfo.js
+++ b/src/profileInfo.js
@@ -107,7 +107,8 @@ class ProfileInfo extends MagisterThing {
 	 * @return {Promise<Stream>}
 	 */
 	getProfilePicture(width = 640, height = 640, crop = false) {
-		const url = `${this._magister._personUrl}/foto?width=${width}&height=${height}&crop=${crop}`
+		const personUrl = `${this._magister.school.url}/api/personen/${this.id}`
+		const url = `${personUrl}/foto?width=${width}&height=${height}&crop=${crop}`
 		return this._magister.http.get(url).then(res => res.body)
 	}
 


### PR DESCRIPTION
fix for getProfilePicture when using parent credentials

I'm not sure if the root cause is not something else... 
In magister.js the personUrl for a child differs from the parent. Should it really be fixed there somehow?
```
m._personUrl = `${this.school.url}/api/personen/${raw.Id}`
```
versus
```
this._personUrl = `${schoolUrl}/api/personen/${id}`
```