### PR TITLE
 Stricter person lookups in tests

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -372,7 +372,7 @@ describe('Magister', function() {
 		})
 
 		it('should get persons', function () {
-			personPromise = m.persons(`${m.profileInfo.getFullName(false)}`)
+			personPromise = m.persons(m.profileInfo.getFullName(false))
 			return personPromise.then(r => {
 				expect(r).to.be.an('array')
 				expect(r).to.not.be.empty

--- a/test/test.js
+++ b/test/test.js
@@ -372,7 +372,7 @@ describe('Magister', function() {
 		})
 
 		it('should get persons', function () {
-			personPromise = m.persons(m.profileInfo.firstName)
+			personPromise = m.persons(`${m.profileInfo.getFullName(false)}`)
 			return personPromise.then(r => {
 				expect(r).to.be.an('array')
 				expect(r).to.not.be.empty


### PR DESCRIPTION
I recently ran tests which, to my surprise, ended up messaging every person in my school that shares the same first name. In order to avoid such things in the future, I made the person lookup a bit stricter (taking both first and last name). The reason I'm using `useBirthName=false` is simply that it else won't find any results.
