### PR TITLE
File folder

### DIFF
--- a/src/course.js
+++ b/src/course.js
@@ -98,8 +98,8 @@ class Course extends MagisterThing {
 	grades({ fillGrades = true, latest = false } = {}) {
 		const urlPrefix = `${this._magister._personUrl}/aanmeldingen/${this.id}/cijfers`
 		const url = latest
-		? `${this._magister._personUrl}/cijfers/laatste?top=50&skip=0`
-		: `${urlPrefix}/cijferoverzichtvooraanmelding?actievePerioden=false&alleenBerekendeKolommen=false&alleenPTAKolommen=false`
+			? `${this._magister._personUrl}/cijfers/laatste?top=50&skip=0`
+			: `${urlPrefix}/cijferoverzichtvooraanmelding?actievePerioden=false&alleenBerekendeKolommen=false&alleenPTAKolommen=false`
 
 		return this._magister._privileges.needs('cijfers', 'read')
 		.then(() => this._magister.http.get(url))

--- a/src/file.js
+++ b/src/file.js
@@ -23,7 +23,7 @@ class File extends MagisterThing {
 		 * @type {Number}
 		 * @readonly
 		 */
-		this.type = raw.BronSoort // REVIEW: string?
+		this.type = raw.BronSoort // REVIEW: string? And there is a difference in Magister between the Type and BronSoort
 		/**
 		 * @type {String}
 		 * @readonly

--- a/src/fileFolder.js
+++ b/src/fileFolder.js
@@ -43,7 +43,7 @@ class FileFolder extends MagisterThing {
 		.then(() => this._magister.http.get(url))
 		.then(res => res.json())
 		.then(res => {
-			const promises = res.Items.map(f => {
+			const promises = res.Items.filter(item => item.BronSoort !== 0).map(f => {
 				const file = new File(this._magister, this, f)
 				return fillPersons ?
 					file.addedBy.getFilled().then(() => file) :
@@ -51,6 +51,13 @@ class FileFolder extends MagisterThing {
 			})
 			return Promise.all(promises)
 		})
+	}
+
+	/**
+	 * @return {Promise<FileFolder[]>}
+	 */
+	folders() {
+		return this._magister.fileFolders(this.id)
 	}
 }
 

--- a/src/fileFolder.js
+++ b/src/fileFolder.js
@@ -43,7 +43,7 @@ class FileFolder extends MagisterThing {
 		.then(() => this._magister.http.get(url))
 		.then(res => res.json())
 		.then(res => {
-			const promises = res.Items.filter(item => item.BronSoort !== 0).map(f => {
+			const promises = res.Items.filter(item => [0, 1, 2, 4].includes(item.Type)).map(f => {
 				const file = new File(this._magister, this, f)
 				return fillPersons ?
 					file.addedBy.getFilled().then(() => file) :

--- a/src/magister.js
+++ b/src/magister.js
@@ -324,7 +324,7 @@ class Magister {
 			}
 		})
 		.then(res => res.json())
-		.then(res => res.Items.map(f => new FileFolder(this, f)))
+		.then(res => res.Items.filter(item => item.BronSoort === 0).map(f => new FileFolder(this, f)))
 	}
 
 	/**

--- a/src/magister.js
+++ b/src/magister.js
@@ -311,11 +311,18 @@ class Magister {
 	}
 
 	/**
+	 * @param {Integer} [parentId = 0]
 	 * @return {Promise<FileFolder[]>}
 	 */
-	fileFolders() {
+	fileFolders(parentId = 0) {
 		return this._privileges.needs('bronnen', 'read')
-		.then(() => this.http.get(`${this._personUrl}/bronnen?soort=0`))
+		.then(() => {
+			if (parentId === 0) {
+				return this.http.get(`${this._personUrl}/bronnen?soort=0`)
+			} else {
+				return this.http.get(`${this._personUrl}/bronnen?soort=0&parentId=${parentId}`)
+			}
+		})
 		.then(res => res.json())
 		.then(res => res.Items.map(f => new FileFolder(this, f)))
 	}

--- a/src/magister.js
+++ b/src/magister.js
@@ -323,7 +323,9 @@ class Magister {
 			return this.http.get(url)
 		})
 		.then(res => res.json())
-		.then(res => res.Items.filter(item => item.BronSoort === 0).map(f => new FileFolder(this, f)))
+		.then(res => {
+			return res.Items.filter(item => ![0, 1, 2, 4].includes(item.Type)).map(f => new FileFolder(this, f))
+		})
 	}
 
 	/**

--- a/src/magister.js
+++ b/src/magister.js
@@ -317,11 +317,10 @@ class Magister {
 	fileFolders(parentId = 0) {
 		return this._privileges.needs('bronnen', 'read')
 		.then(() => {
-			if (parentId === 0) {
-				return this.http.get(`${this._personUrl}/bronnen?soort=0`)
-			} else {
-				return this.http.get(`${this._personUrl}/bronnen?soort=0&parentId=${parentId}`)
-			}
+			let url = `${this._personUrl}/bronnen?soort=0`
+			if (parentId !== 0) { url += `&parentId=${parentId}` }
+
+			return this.http.get(url)
 		})
 		.then(res => res.json())
 		.then(res => res.Items.filter(item => item.BronSoort === 0).map(f => new FileFolder(this, f)))

--- a/test/test.js
+++ b/test/test.js
@@ -307,7 +307,7 @@ describe('Magister', function() {
 
 	describe('file', function () {
 		it('should download files', function () {
-			return m.fileFolders()
+			return m.fileFolders(0)
 			.then(folders => {
 				expect(folders).to.be.an('array')
 				for (const f of folders) {


### PR DESCRIPTION
I slightly changed and added to the `#fileFolders` method so you can also fetch subfolders. I added filters to both `#fileFolders` and `FileFolder#files` as I noticed the `soort=` parameter didn't always work (or maybe I am seeing ghosts).

```js
if (parentId === 0) {
    return this.http.get(`${this._personUrl}/bronnen?soort=0`)
} else {
    return this.http.get(`${this._personUrl}/bronnen?soort=0&parentId=${parentId}`)
}
```

The reason for this `if`-statement is that the Magister API thinks that `parentId=0` is an invalid parameter.

In the future instead of filtering using the `BronSoort` attribute we might want to look at the `UniqueId` attribute. I noticed that all folders have a `UniqueId` of `00000000-0000-0000-0000-000000000000` (not sure how that still is a "unique" ID if all folders have it.. but hey, not my problem). And according to Magister the `BronSoort=0` is for unspecified filetypes, which probably is exclusively folders but that's unsure.

Edit:

I tested the function manually as I have no clue how I'd write a consistent and meaningful test for this. 