### PR TITLE
Check if recipients are included if not use an empty array.

### DIFF
--- a/src/message.js
+++ b/src/message.js
@@ -56,7 +56,7 @@ class Message extends MagisterThing {
 			this._type = raw.Soort
 			this.subject = raw.Onderwerp
 			this.body = undefined
-			this.recipients = raw.Ontvangers.map(p => new Person(magister, p))
+			this.recipients = (raw.Ontvangers || []).map(p => new Person(magister, p))
 
 			/**
 			 * @type {String}


### PR DESCRIPTION
For some reason, not all messages sent by our school have a recipients array (don't ask me why.. makes no sense to me either). This issue mainly occurs in school-wide announcements. When fetching the message it would throw an error since the `raw.Ontvangers` object would be undefined. In order to circumvent this problem, I decided to pass in an empty array if that's the case.