### PR TITLE
Fix for issue #132

### DIFF
--- a/src/appointment.js
+++ b/src/appointment.js
@@ -241,9 +241,10 @@ class Appointment extends MagisterThing {
 	 * @returns {Promise}
 	 */
 	remove() {
-		if (this.type !== 1 && this.type !== 16) {
-			return Promise.reject(new Error('Appointment not created by user'))
-		}
+		// TODO: enable this check again when we have decided on which `InfoType` to use.
+		// if (this.type !== 1 && this.type !== 16) {
+		// 	return Promise.reject(new Error('Appointment not created by user'))
+		// }
 
 		return this._magister._privileges.needs('afspraken', 'delete')
 		.then(() => this._magister.http.delete(this._url))

--- a/src/appointment.js
+++ b/src/appointment.js
@@ -241,10 +241,9 @@ class Appointment extends MagisterThing {
 	 * @returns {Promise}
 	 */
 	remove() {
-		// TODO: enable this check again when we have decided on which `InfoType` to use.
-		// if (this.type !== 1 && this.type !== 16) {
-		// 	return Promise.reject(new Error('Appointment not created by user'))
-		// }
+		if (this.type !== 'personal' && this.type !== 'schedule') {
+			return Promise.reject(new Error('Appointment not created by user'))
+		}
 
 		return this._magister._privileges.needs('afspraken', 'delete')
 		.then(() => this._magister.http.delete(this._url))

--- a/src/magister.js
+++ b/src/magister.js
@@ -288,7 +288,7 @@ class Magister {
 			DuurtHeleDag: options.fullDay || false,
 
 			// Static non-configurable stuff.
-			InfoType: 0,
+			InfoType: 6,
 			WeergaveType: 1,
 			Status: 2,
 			HeeftBijlagen: false,

--- a/src/magister.js
+++ b/src/magister.js
@@ -288,7 +288,7 @@ class Magister {
 			DuurtHeleDag: options.fullDay || false,
 
 			// Static non-configurable stuff.
-			InfoType: 6,
+			InfoType: 0,
 			WeergaveType: 1,
 			Status: 2,
 			HeeftBijlagen: false,

--- a/test/test.js
+++ b/test/test.js
@@ -197,7 +197,11 @@ describe('Magister', function() {
 	// TODO: add tests for fillPersons option
 	describe('appointment', function () {
 		it('should fetch appointments', function () {
-			return m.appointments(new Date()).then(r => {
+			var now = new Date()
+			var today = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+			var nextWeek = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 7)
+
+			return m.appointments(today, nextWeek).then(r => {
 				expect(r).to.be.an('array')
 
 				for (const appointment of r) {
@@ -237,15 +241,19 @@ describe('Magister', function() {
 		})
 
 		it('should be able to create appointments and delete them', function () {
-			const now = new Date()
+			var now = new Date()
+			var today = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+			var tomorrow = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1)
+			var nextWeek = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 7)
+
 			const description = 'magister.js test appointment'
 
 			return m.createAppointment({
-				start: now,
-				end: new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1),
+				start: today,
+				end: tomorrow,
 				description,
 			}).then(() => {
-				return m.appointments(now).then(r => {
+				return m.appointments(today, nextWeek).then(r => {
 					const appointment = r.find(a => a.description === description)
 					expect(appointment).to.exist
 					return appointment.remove()


### PR DESCRIPTION
After some testing, it appears that #132 is being caused by changes in #125. Reverting those changes fixes #132. However, life wouldn't be life if it was that easy. As mentioned by @Sj3rd and looking at the requests Magister makes itself it appears that `InfoType` should indeed be set to `6` instead of `0`. But that breaks stuff.

So @Sj3rd any ideas from you? Is there something else that we need to change perhaps in order to be able to use `InfoType: 6`?

Edit: There now is an issue with deleting the appointment. Not sure how I didn't catch it the first time.
```
2) Magister
       appointment
         should be able to create appointments and delete them:
     Error: Appointment not created by user
      at Appointment.remove (src/appointment.js:137:221)
      at remove (test/test.js:259:25)
      at processTicksAndRejections (internal/process/next_tick.js:81:5)
```
I suspect that it is trying to delete a different appointment as I can delete it myself just fine.