### PR TITLE
Fix fetching grades from previous years

### DIFF
--- a/src/course.js
+++ b/src/course.js
@@ -99,7 +99,7 @@ class Course extends MagisterThing {
 		const urlPrefix = `${this._magister._personUrl}/aanmeldingen/${this.id}/cijfers`
 		const url = latest
 			? `${this._magister._personUrl}/cijfers/laatste?top=50&skip=0`
-			: `${urlPrefix}/cijferoverzichtvooraanmelding?actievePerioden=false&alleenBerekendeKolommen=false&alleenPTAKolommen=false`
+			: `${urlPrefix}/cijferoverzichtvooraanmelding?actievePerioden=false&alleenBerekendeKolommen=false&alleenPTAKolommen=false&peildatum=${this.end.getFullYear()}-${this.end.getMonth()+1}-${this.end.getDate()}`
 
 		return this._magister._privileges.needs('cijfers', 'read')
 		.then(() => this._magister.http.get(url))


### PR DESCRIPTION
Should fix issue #102 where no grades from non-active courses could be fetched.
Although I tested this myself I encourage you to do some of your own testing.

Much love,
Rein