### PR TITLE
Fix response error handling

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -121,7 +121,7 @@ class Http {
 				this._setRatelimitTime(Number.parseInt(parsed.SecondsLeft, 10))
 				return this._request(obj)
 			}
-			if ('error' in parsed) {
+			else if ('error' in parsed) {
 				error.message = parsed.error;
 			}
 		} catch (_) {}

--- a/src/http.js
+++ b/src/http.js
@@ -110,6 +110,9 @@ class Http {
 		if (res.ok || res.status === 302) {
 			return res
 		}
+		
+		const error = new Error(res.statusText);
+		error.res = res;
 
 		try {
 			const parsed = await res.json()
@@ -119,10 +122,11 @@ class Http {
 				return this._request(obj)
 			}
 			if ('error' in parsed) {
-				res.error = parsed.error
+				error.message = parsed.error;
 			}
 		} catch (_) {}
-		return res
+		
+		throw error;
 	}
 
 	/**

--- a/src/http.js
+++ b/src/http.js
@@ -112,16 +112,17 @@ class Http {
 		}
 
 		try {
-			const body = await res.body()
-			const parsed = JSON.parse(body)
+			const parsed = await res.json()
 			if ('SecondsLeft' in parsed) {
 				// Handle rate limit errors
 				this._setRatelimitTime(Number.parseInt(parsed.SecondsLeft, 10))
 				return this._request(obj)
 			}
-		} catch (_) {
-			return res
-		}
+			if ('error' in parsed) {
+				res.error = parsed.error
+			}
+		} catch (_) {}
+		return res
 	}
 
 	/**


### PR DESCRIPTION
I was running into some issues with this code, but wasn't sure what the intention was. This is what I made of it:

* First of all, it was calling `res.body()` which always fails since `body` is not a function. I've fixed this by turning it into `await res.json()`, replacing the `JSON.parse()` as well.

* Secondly, looking at the calling code, it seems it's expecting `res` to possibly have an `error` property. I've added the error from the JSON response.

* Finally, if no error was caught, the function did not return any res at all, so I moved the return out of the catch so that it's always returned.

Hope this helps, thanks!