### PR TITLE
Revert AuthError 

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -111,9 +111,6 @@ class Http {
 			return res
 		}
 
-		const error = new Error(res.statusText)
-		error.res = res
-
 		try {
 			const parsed = await res.json()
 			if ('SecondsLeft' in parsed) {
@@ -125,7 +122,7 @@ class Http {
 			}
 		} catch (_) {}
 
-		throw error
+		return res
 	}
 
 	/**

--- a/test/test.js
+++ b/test/test.js
@@ -100,7 +100,7 @@ describe('Magister', function() {
 			...options,
 			username: 'xxx',
 			password: 'xxx',
-		})).to.be.rejectedWith(/Invalid/)
+		})).to.be.rejectedWith(magisterjs.AuthError)
 	})
 
 	it('should be able to reuthenticate with a token', function () {


### PR DESCRIPTION
I think we might want to revert the `AuthError` changes for now as suggested by @LevitatingBusinessMan so we can focus on cleaning up the authentication flow. When we have a fully working flow we can focus on proper error handling again.