### PR TITLE
Use authCode from config again

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@magisterjs/authcode": "*",
     "dedent": "^0.7.0",
     "lodash": "^4.17.11",
-    "magister-openid": "^0.1.2",
+    "magister-openid": "^0.1.4",
     "moment": "^2.24.0",
     "node-fetch": "^2.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@magisterjs/authcode": "*",
     "dedent": "^0.7.0",
     "lodash": "^4.17.11",
-    "magister-openid": "^0.1.4",
+    "magister-openid": "^0.1.5",
     "moment": "^2.24.0",
     "node-fetch": "^2.6.0"
   },

--- a/src/magister.js
+++ b/src/magister.js
@@ -433,7 +433,7 @@ class Magister {
 				throw new AuthError(error)
 			})
 		} else {
-			await this.authManager.login(options.username, options.password)
+			await this.authManager.login(options.username, options.password, options.authCode)
 			.catch(error => {
 				throw new AuthError(error)
 			})


### PR DESCRIPTION
After the switch to magister-openid, the given authCode was no longer used, since magister-openid had its own (outdated) authCode. This has since been fixed in v0.1.4 with a breaking change requiring to pass along the authCode.

This PR fixes the backwards incompatibility by requiring at least 0.1.4 and passes the authCode along to magister-openid.

The reason we need to be able to pass an authCode is that magisterjs-authcode is no longer updated, see https://github.com/simplyGits/magisterjs-authcode/issues/4. Any idea why that is? I had to create my own automatic authcode update tool (https://github.com/robbertkl/magister-authcode).